### PR TITLE
Auto-approve dependabot and pre-commit PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |
-    		  gh pr review --approve "$PR_URL"
-    		  gh pr merge --auto --merge "$PR_URL"
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           # GitHub provides this variable in the CI env. You don't


### PR DESCRIPTION
# Description

This is required to enable the auto-merge functionality to pass the branch protection requirements.

Will allow the current PRs to merge automatically.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
