### PR TITLE
Update UI message feed via polling

### DIFF
--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -56,9 +56,9 @@
         </div>
         <div class="card-body" id="message-list">
           <ul class="list-group">
-            {% if messages %}
-              {% for message in messages %}<li class="list-group-item">{{ message }}</li>{% endfor %}
-            {% endif %}
+            <div hx-get="{% url 'process_manager:messages' %}"
+                 hx-trigger="every 1s"
+                 hx-swap="afterend"></div>
           </ul>
         </div>
       </div>

--- a/process_manager/templates/process_manager/partials/message_items.html
+++ b/process_manager/templates/process_manager/partials/message_items.html
@@ -1,0 +1,1 @@
+{% for message in messages %}<li class="list-group-item">{{ message }}</li>{% endfor %}

--- a/process_manager/urls.py
+++ b/process_manager/urls.py
@@ -8,6 +8,7 @@ app_name = "process_manager"
 
 partial_urlpatterns = [
     path("process_table/", partials.process_table, name="process_table"),
+    path("messages/", partials.messages, name="messages"),
 ]
 
 urlpatterns = [

--- a/process_manager/views/pages.py
+++ b/process_manager/views/pages.py
@@ -4,7 +4,6 @@ import uuid
 
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse_lazy
@@ -17,16 +16,7 @@ from ..process_manager_interface import boot_process, get_process_logs
 @login_required
 def index(request: HttpRequest) -> HttpResponse:
     """View that renders the index/home page."""
-    with transaction.atomic():
-        # atomic to avoid race condition with kafka consumer
-        messages = request.session.load().get("messages", [])
-        request.session.pop("messages", [])
-        request.session.save()
-
-    context = {"messages": messages}
-    return render(
-        request=request, context=context, template_name="process_manager/index.html"
-    )
+    return render(request=request, template_name="process_manager/index.html")
 
 
 @login_required

--- a/process_manager/views/partials.py
+++ b/process_manager/views/partials.py
@@ -2,6 +2,7 @@
 
 import django_tables2
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from druncschema.process_manager_pb2 import (
@@ -51,4 +52,20 @@ def process_table(request: HttpRequest) -> HttpResponse:
         request=request,
         context=dict(table=table),
         template_name="process_manager/partials/process_table.html",
+    )
+
+
+@login_required
+def messages(request: HttpRequest) -> HttpResponse:
+    """Renders and pops Kafka messages from the user's session."""
+    with transaction.atomic():
+        # atomic to avoid race condition with kafka consumer
+        messages = request.session.load().get("messages", [])
+        request.session.pop("messages", [])
+        request.session.save()
+
+    return render(
+        request=request,
+        context=dict(messages=messages[::-1]),
+        template_name="process_manager/partials/message_items.html",
     )

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -18,24 +18,6 @@ class TestIndexView(LoginRequiredTest):
             response = auth_client.get(self.endpoint)
         assert response.status_code == HTTPStatus.OK
 
-    def test_session_messages(self, auth_client):
-        """Test the rendering of messages from the user session into the view."""
-        from django.contrib.sessions.backends.db import SessionStore
-        from django.contrib.sessions.models import Session
-
-        session = Session.objects.get()
-        message_data = ["message 1", "message 2"]
-        store = SessionStore(session_key=session.session_key)
-        store["messages"] = message_data
-        store.save()
-
-        response = auth_client.get(self.endpoint)
-        assert response.status_code == HTTPStatus.OK
-
-        # messages have been removed from the session and added to the context
-        assert response.context["messages"] == message_data
-        assert "messages" not in store.load()
-
 
 class TestLogsView(PermissionRequiredTest):
     """Tests for the logs view."""


### PR DESCRIPTION
# Description

This PR makes the Kafka message feed auto-update. It:

- Creates a separate partial template for the contents of the message feed.
- Adds a dedicated partial view function to render message data into the template.
- Updates the process_manager index page template to include a htmx element that polls the messages view and populates new messages into the page.

Fixes #121

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
