### PR TITLE
Kafka message filtering

### DIFF
--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -53,14 +53,12 @@
                type="search"
                name="search"
                placeholder="Search..."
-               hx-get="{% url 'process_manager:process_table' %}"
                hx-trigger="input changed delay:500ms, every 1s"
-               hx-target="div.table-container"
-               hx-swap="innerHTML">
+               hx-get="{% url 'process_manager:process_table' %}"
+               hx-target="div.table-container">
         <div id="table-container"
-             hx-get="{% url 'process_manager:process_table' %}"
-             hx-swap="innerHTML"
-             hx-trigger="load"></div>
+             hx-trigger="load"
+             hx-get="{% url 'process_manager:process_table' %}"></div>
       </form>
     </div>
     <div class="col" id="message-panel">
@@ -73,13 +71,10 @@
                   aria-label="Hide Messages"
                   _="on click hide #message-panel show #show-messages-button"></button>
         </div>
-        <div class="card-body" id="message-list">
-          <ul class="list-group">
-            <div hx-get="{% url 'process_manager:messages' %}"
-                 hx-swap="outerHTML"
-                 hx-trigger="load"></div>
-          </ul>
-        </div>
+        <div id="message-list"
+             class="card-body"
+             hx-trigger="load, every 1s"
+             hx-get="{% url 'process_manager:messages' %}"></div>
       </div>
     </div>
   </div>

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -53,12 +53,12 @@
                type="search"
                name="search"
                placeholder="Search..."
-               hx-trigger="input changed delay:500ms, every 1s"
                hx-get="{% url 'process_manager:process_table' %}"
-               hx-target="#table-container">
+               hx-trigger="input changed delay:500ms, every 1s"
+               hx-target="div.table-container">
         <div id="table-container"
-             hx-trigger="load"
-             hx-get="{% url 'process_manager:process_table' %}"></div>
+             hx-get="{% url 'process_manager:process_table' %}"
+             hx-trigger="load"></div>
       </form>
     </div>
     <div class="col" id="message-panel">
@@ -74,14 +74,14 @@
                  type="search"
                  name="search"
                  placeholder="Search..."
-                 hx-trigger="input changed delay:500ms, every 1s"
                  hx-get="{% url 'process_manager:messages' %}"
+                 hx-trigger="input changed delay:500ms, every 1s"
                  hx-target="#message-list">
         </div>
         <div id="message-list"
              class="card-body"
-             hx-trigger="load"
-             hx-get="{% url 'process_manager:messages' %}"></div>
+             hx-get="{% url 'process_manager:messages' %}"
+             hx-trigger="load"></div>
       </div>
     </div>
   </div>

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -8,7 +8,7 @@
       float: right;
     }
     #message-list {
-      max-height: 85vh;
+      max-height: 80vh;
       overflow-y: auto;
     }
   </style>

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -55,7 +55,7 @@
                placeholder="Search..."
                hx-trigger="input changed delay:500ms, every 1s"
                hx-get="{% url 'process_manager:process_table' %}"
-               hx-target="div.table-container">
+               hx-target="#table-container">
         <div id="table-container"
              hx-trigger="load"
              hx-get="{% url 'process_manager:process_table' %}"></div>
@@ -70,10 +70,17 @@
                   class="btn-close"
                   aria-label="Hide Messages"
                   _="on click hide #message-panel show #show-messages-button"></button>
+          <input class="form-control"
+                 type="search"
+                 name="search"
+                 placeholder="Search..."
+                 hx-trigger="input changed delay:500ms, every 1s"
+                 hx-get="{% url 'process_manager:messages' %}"
+                 hx-target="#message-list">
         </div>
         <div id="message-list"
              class="card-body"
-             hx-trigger="load, every 1s"
+             hx-trigger="load"
              hx-get="{% url 'process_manager:messages' %}"></div>
       </div>
     </div>

--- a/process_manager/templates/process_manager/partials/message_items.html
+++ b/process_manager/templates/process_manager/partials/message_items.html
@@ -1,5 +1,3 @@
-<div hx-get="{% url 'process_manager:messages' %}"
-     hx-trigger="load delay:1s"
-     hx-swap="outerHTML">
+<ul class="list-group">
   {% for message in messages %}<li class="list-group-item">{{ message }}</li>{% endfor %}
-</div>
+</ul>

--- a/process_manager/views/partials.py
+++ b/process_manager/views/partials.py
@@ -96,14 +96,11 @@ def process_table(request: HttpRequest) -> HttpResponse:
 @login_required
 def messages(request: HttpRequest) -> HttpResponse:
     """Renders Kafka messages from the database."""
-    search = request.GET.get("search", "").lower()
-
     messages = []
-    for msg in DruncMessage.objects.all():
-        # Filter messages based on search parameter.
-        if search not in msg.message.lower():
-            continue
 
+    # Filter messages based on search parameter.
+    search = request.GET.get("search", "")
+    for msg in DruncMessage.objects.filter(message__icontains=search):
         # Time is stored as UTC. localtime(t) converts this to our configured timezone.
         timestamp = localtime(msg.timestamp).strftime("%Y-%m-%d %H:%M:%S")
 

--- a/process_manager/views/partials.py
+++ b/process_manager/views/partials.py
@@ -96,10 +96,17 @@ def process_table(request: HttpRequest) -> HttpResponse:
 @login_required
 def messages(request: HttpRequest) -> HttpResponse:
     """Renders Kafka messages from the database."""
+    search = request.GET.get("search", "").lower()
+
     messages = []
     for msg in DruncMessage.objects.all():
+        # Filter messages based on search parameter.
+        if search not in msg.message.lower():
+            continue
+
         # Time is stored as UTC. localtime(t) converts this to our configured timezone.
         timestamp = localtime(msg.timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
         messages.append(f"{timestamp}: {msg.message}")
 
     return render(

--- a/tests/process_manager/views/test_partial_views.py
+++ b/tests/process_manager/views/test_partial_views.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -7,6 +8,7 @@ from django.test import Client
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
+from main.models import DruncMessage
 from process_manager.tables import ProcessTable
 
 from ...utils import LoginRequiredTest
@@ -60,10 +62,6 @@ class TestMessagesView(LoginRequiredTest):
 
     def test_get(self, auth_client):
         """Tests basic calls of view method."""
-        from datetime import UTC, datetime, timedelta
-
-        from main.models import DruncMessage
-
         t1 = datetime.now(tz=UTC)
         t2 = t1 + timedelta(minutes=10)
         DruncMessage.objects.bulk_create(
@@ -85,10 +83,6 @@ class TestMessagesView(LoginRequiredTest):
 
     def test_get_with_search(self, auth_client):
         """Tests message filtering of view method."""
-        from datetime import UTC, datetime
-
-        from main.models import DruncMessage
-
         t = datetime.now(tz=UTC)
         t_str = t.strftime("%Y-%m-%d %H:%M:%S")
         her_msg = "her message"


### PR DESCRIPTION
# Description

This PR enables filtering of Kafka messages in the message feed. Searching is case-insensitive. The timestamp is *not* considered by the search.

![Screenshot from 2024-10-18 14-02-24](https://github.com/user-attachments/assets/0ab9d995-a805-499a-9b21-a53a0e7df38b)

Also tests are added, and partial template/triggers are cleaned a little.

Fixes #122 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
