### PR TITLE
Disable action buttons if not checkbox is selcted

### DIFF
--- a/process_manager/tables.py
+++ b/process_manager/tables.py
@@ -57,5 +57,6 @@ class ProcessTable(tables.Table):
         """
         return mark_safe(
             f'<input type="checkbox" name="select" value="{value}" id="{value}-input" '
-            f'hx-preserve="true" class="row-checkbox" _="{row_checkbox_hyperscript}"'
+            f'hx-preserve="true" class="row-checkbox" _="{row_checkbox_hyperscript}" '
+            f'onchange="updateButtonState()">'
         )

--- a/process_manager/tables.py
+++ b/process_manager/tables.py
@@ -9,14 +9,6 @@ logs_column_template = (
 
 header_checkbox_hyperscript = """
 on click set .row-checkbox.checked to my.checked
-if my.checked
-    set #killButton.disabled to false
-    set #restartButton.disabled to false
-    set #flushButton.disabled to false
-else
-    set #killButton.disabled to true
-    set #restartButton.disabled to true
-    set #flushButton.disabled to true
 """
 
 row_checkbox_hyperscript = """
@@ -67,5 +59,5 @@ class ProcessTable(tables.Table):
         """
         return mark_safe(
             f'<input type="checkbox" name="select" value="{value}" id="{value}-input" '
-            f'hx-preserve="true" class="row-checkbox" _="{row_checkbox_hyperscript}" '
+            f'hx-preserve="true" class="row-checkbox" _="{row_checkbox_hyperscript}"'
         )

--- a/process_manager/tables.py
+++ b/process_manager/tables.py
@@ -7,7 +7,17 @@ logs_column_template = (
     "<a href=\"{% url 'process_manager:logs' record.uuid %}\">LOGS</a>"
 )
 
-header_checkbox_hyperscript = "on click set .row-checkbox.checked to my.checked"
+header_checkbox_hyperscript = """
+on click set .row-checkbox.checked to my.checked
+if my.checked
+    set #killButton.disabled to false
+    set #restartButton.disabled to false
+    set #flushButton.disabled to false
+else
+    set #killButton.disabled to true
+    set #restartButton.disabled to true
+    set #flushButton.disabled to true
+"""
 
 row_checkbox_hyperscript = """
 on click
@@ -58,5 +68,4 @@ class ProcessTable(tables.Table):
         return mark_safe(
             f'<input type="checkbox" name="select" value="{value}" id="{value}-input" '
             f'hx-preserve="true" class="row-checkbox" _="{row_checkbox_hyperscript}" '
-            f'onchange="updateButtonState()">'
         )

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -17,11 +17,30 @@
 {% endblock extra_css %}
 {% block extra_js %}
   <script language="JavaScript">
-  function toggle(source) {
-      checkboxes = document.getElementsByName('select');
-      for(var i in checkboxes)
-          checkboxes[i].checked = source.checked;
-  }
+        function toggle(source) {
+            const checkboxes = document.getElementsByName('select');
+            for (const checkbox of checkboxes) {
+                checkbox.checked = source.checked;
+            }
+            updateButtonState();
+        }
+
+        function updateButtonState() {
+            const checkboxes = document.getElementsByName('select');
+            const buttons = [
+                document.getElementById('restartButton'),
+                document.getElementById('flushButton'),
+                document.getElementById('killButton')
+            ];
+            const anyChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
+            buttons.forEach(button => button.disabled = !anyChecked);
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            const checkboxes = document.getElementsByName('select');
+            checkboxes.forEach(checkbox => checkbox.addEventListener('change', updateButtonState));
+            updateButtonState();
+        });
   </script>
 {% endblock extra_js %}
 {% block content %}
@@ -35,16 +54,19 @@
                value="Restart"
                class="btn btn-success"
                name="action"
+               id="restartButton"
                onclick="return confirm('Restart selected processes?')">
         <input type="submit"
                value="Flush"
                class="btn btn-warning"
                name="action"
+               id="flushButton"
                onclick="return confirm('Flush selected processes?')">
         <input type="submit"
                value="Kill"
                class="btn btn-danger"
                name="action"
+               id="killButton"
                onclick="return confirm('Kill selected processes?')">
         <button id="show-messages-button"
                 type="button"

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -50,24 +50,26 @@
         {% csrf_token %}
         <a href="{% url 'process_manager:boot_process' %}"
            class="btn btn-primary">Boot</a>
-        <input type="submit"
-               value="Restart"
-               class="btn btn-success"
-               name="action"
-               id="restartButton"
-               onclick="return confirm('Restart selected processes?')">
-        <input type="submit"
-               value="Flush"
-               class="btn btn-warning"
-               name="action"
-               id="flushButton"
-               onclick="return confirm('Flush selected processes?')">
-        <input type="submit"
-               value="Kill"
-               class="btn btn-danger"
-               name="action"
-               id="killButton"
-               onclick="return confirm('Kill selected processes?')">
+        {% if perms.main.can_modify_processes %}
+          <input type="submit"
+                 value="Restart"
+                 class="btn btn-success"
+                 name="action"
+                 id="restartButton"
+                 onclick="return confirm('Restart selected processes?')">
+          <input type="submit"
+                 value="Flush"
+                 class="btn btn-warning"
+                 name="action"
+                 id="flushButton"
+                 onclick="return confirm('Flush selected processes?')">
+          <input type="submit"
+                 value="Kill"
+                 class="btn btn-danger"
+                 name="action"
+                 id="killButton"
+                 onclick="return confirm('Kill selected processes?')">
+        {% endif %}
         <button id="show-messages-button"
                 type="button"
                 class="btn btn-info"

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -16,31 +16,15 @@
   </style>
 {% endblock extra_css %}
 {% block extra_js %}
-  <script language="JavaScript">
-        function toggle(source) {
-            const checkboxes = document.getElementsByName('select');
-            for (const checkbox of checkboxes) {
-                checkbox.checked = source.checked;
-            }
-            updateButtonState();
-        }
-
-        function updateButtonState() {
-            const checkboxes = document.getElementsByName('select');
-            const buttons = [
-                document.getElementById('restartButton'),
-                document.getElementById('flushButton'),
-                document.getElementById('killButton')
-            ];
-            const anyChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
-            buttons.forEach(button => button.disabled = !anyChecked);
-        }
-
-        document.addEventListener('DOMContentLoaded', function() {
-            const checkboxes = document.getElementsByName('select');
-            checkboxes.forEach(checkbox => checkbox.addEventListener('change', updateButtonState));
-            updateButtonState();
-        });
+  <script type="text/hyperscript">
+  behavior disableActionButton
+    on click[target.matches('.row-checkbox')] from elsewhere
+      if <.row-checkbox:checked /> is empty
+        set me.disabled to true
+      else
+        set me.disabled to false
+    end
+    end
   </script>
 {% endblock extra_js %}
 {% block content %}
@@ -56,19 +40,25 @@
                  class="btn btn-success"
                  name="action"
                  id="restartButton"
-                 onclick="return confirm('Restart selected processes?')">
+                 onclick="return confirm('Restart selected processes?')"
+                 disabled
+                 _="install disableActionButton">
           <input type="submit"
                  value="Flush"
                  class="btn btn-warning"
                  name="action"
                  id="flushButton"
-                 onclick="return confirm('Flush selected processes?')">
+                 onclick="return confirm('Flush selected processes?')"
+                 disabled
+                 _="install disableActionButton">
           <input type="submit"
                  value="Kill"
                  class="btn btn-danger"
                  name="action"
                  id="killButton"
-                 onclick="return confirm('Kill selected processes?')">
+                 onclick="return confirm('Kill selected processes?')"
+                 disabled
+                 _="install disableActionButton">
         {% endif %}
         <button id="show-messages-button"
                 type="button"

--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -18,13 +18,13 @@
 {% block extra_js %}
   <script type="text/hyperscript">
   behavior disableActionButton
-    on click[target.matches('.row-checkbox')] from elsewhere
+    on click[target.matches('.row-checkbox')] from elsewhere or click[target.matches('#header-checkbox')] from elsewhere
       if <.row-checkbox:checked /> is empty
         set me.disabled to true
       else
         set me.disabled to false
     end
-    end
+  end
   </script>
 {% endblock extra_js %}
 {% block content %}
@@ -32,9 +32,9 @@
     <div class="col">
       <form method="post" action="{% url 'process_manager:process_action' %}">
         {% csrf_token %}
-        <a href="{% url 'process_manager:boot_process' %}"
-           class="btn btn-primary">Boot</a>
         {% if perms.main.can_modify_processes %}
+          <a href="{% url 'process_manager:boot_process' %}"
+             class="btn btn-primary">Boot</a>
           <input type="submit"
                  value="Restart"
                  class="btn btn-success"


### PR DESCRIPTION
# Description
adds some logic to disable the restart, flush and kill if not checkboxes are selected. 
I have also added the permission to be able to access the button to the permission group "can_modify_processes"

Fixes #90 and #110 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
