### PR TITLE
Fix hard to see msg hide btn.

### DIFF
--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -11,6 +11,10 @@
       max-height: 80vh;
       overflow-y: auto;
     }
+    #hide-messages-button {
+      /* Certain themes invert the colour, so we invert back. */
+      filter: invert(1);
+    }
   </style>
 {% endblock extra_css %}
 {% block extra_js %}


### PR DESCRIPTION
# Description

Fixes difficult to see message hide button. Certain themes invert the colour, so just invert back.

Fixes #180. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
