### PR TITLE
Enable `drunc` compose profile to build on MacOS

### DIFF
--- a/drunc_docker_service/Dockerfile
+++ b/drunc_docker_service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /basedir
 # setup for the the dune development environment that provides the full set of
 # dependencies required for booting of the controller test session
 # See https://github.com/DUNE-DAQ/drunc/wiki/Setup-drunc-with-DUNE-DAQ for explanation
+ENV SPACK_ROOT /cvmfs/dunedaq.opensciencegrid.org/spack/releases/fddaq-v5.1.0-a9-1/spack-0.20.0
 RUN source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh && \
         setup_dbt latest_v5 && \
         dbt-create fddaq-v5.1.0-a9 fddaq-v5.1.0-a9 && \


### PR DESCRIPTION
# Description

This PR makes the full `drunc` compose profile work on MacOS. Previously there was an error about a `SPACK_ROOT` environment variable not being set. Thanks to @cc-a for helping find what that environment variable should be.

**Note:** This makes changes to the Dockerfile, so it should be tested on all different operating systems before merging. Tick the box if it works for you:
- [x] MacOS
- [ ] Windows
- [x] Linux

Fixes #209 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
