### PR TITLE
Add pop-up to input arguments

### DIFF
--- a/controller/fsm.py
+++ b/controller/fsm.py
@@ -1,5 +1,7 @@
 """Module that implements `drunc` finite state machine."""
 
+from typing import Any
+
 from statemachine import State, StateMachine
 
 from . import controller_interface as ci
@@ -81,7 +83,7 @@ class DruncFSM(StateMachine):
             "Triggered_Sources_Stopped",
         ]
 
-    def send(self, event: str, **kwargs: dict[str, str]) -> None:
+    def send(self, event: str, **kwargs: dict[str, Any]) -> None:  # type: ignore[misc]
         """Send an event to the FSM.
 
         This method sends the event to the FSM and only if the response is
@@ -91,7 +93,7 @@ class DruncFSM(StateMachine):
 
         Args:
             event (str): The event to send.
-            **kwargs (dict[str, str]): The arguments for the event.
+            **kwargs (dict[str, Any]): The arguments for the event.
         """
         super().send(event, **kwargs)
 

--- a/controller/tables.py
+++ b/controller/tables.py
@@ -108,7 +108,7 @@ def toggle_button(event: str, current: bool) -> SafeString:
         str: The button as a safe string.
     """
     if current:
-        action = f"hx-post={reverse('controller:state_machine')} hx-target='#state-machine' hx-include='#event_{event}'"  # noqa: E501
+        action = f"hx-post={reverse('controller:dialog')} hx-target='#htmx-dialog-container' hx-include='#event_{event}'"  # noqa: E501
         return mark_safe(
             f"<button {action} class='btn btn-success w-100 mx-2' >{event}</button>"
         )

--- a/controller/templates/controller/index.html
+++ b/controller/templates/controller/index.html
@@ -45,4 +45,11 @@
       {% include "main/messages.html" with topic="ERS" %}
     </div>
   </div>
+  <div id="htmx-dialog-container"
+       _="on htmx:afterSettle call (first of me).showModal()"></div>
+  <div class="col-2">
+    <button class="btn btn-primary w-100"
+            hx-get="{% url 'controller:dialog' %}"
+            hx-target="#htmx-dialog-container">Show the classical dialog</button>
+  </div>
 {% endblock content %}

--- a/controller/templates/controller/index.html
+++ b/controller/templates/controller/index.html
@@ -47,9 +47,4 @@
   </div>
   <div id="htmx-dialog-container"
        _="on htmx:afterSettle call (first of me).showModal()"></div>
-  <div class="col-2">
-    <button class="btn btn-primary w-100"
-            hx-get="{% url 'controller:dialog' %}"
-            hx-target="#htmx-dialog-container">Show the classical dialog</button>
-  </div>
 {% endblock content %}

--- a/controller/templates/controller/partials/arguments_dialog.html
+++ b/controller/templates/controller/partials/arguments_dialog.html
@@ -1,0 +1,32 @@
+<dialog class="dialog"
+        _="on dialog_close remove me on keydown if the event's key is 'Escape' remove me">
+  <form method="dialog">
+    <div class="dialog-header">
+      <h4 class="dialog-title">Arguments to run transition: {{ event }}</h4>
+    </div>
+    <form>
+      {% csrf_token %}
+      <div class="dialog-body">
+        {% for arg in args %}
+          <div class="mb-3">
+            <label for="{{ arg }}" class="form-label">{{ arg }}</label>
+            <input type="text"
+                   class="form-control"
+                   id="{{ arg }}"
+                   name="{{ arg }}"
+                   required>
+          </div>
+        {% endfor %}
+      </div>
+      <div class="d-flex justify-content-between mb-3">
+        <input type="hidden" name="current_state" value="{{ current_state }}">
+        <input type="hidden" name="event" value="{{ event }}">
+        <button class="btn btn-danger w-50 mx-2" _="on click send dialog_close">Cancel</button>
+        <button class="btn btn-success w-50 mx-2"
+                hx-post="{% url 'controller:state_machine' %}"
+                hx-target='#state-machine'
+                _="on click send dialog_close">Submit</button>
+      </div>
+    </form>
+  </form>
+</dialog>

--- a/controller/urls.py
+++ b/controller/urls.py
@@ -8,6 +8,7 @@ app_name = "controller"
 
 partial_urlpatterns = [
     path("state_machine", partials.state_machine, name="state_machine"),
+    path("dialog", partials.dialog, name="dialog"),
 ]
 
 urlpatterns = [

--- a/controller/views/partials.py
+++ b/controller/views/partials.py
@@ -40,6 +40,7 @@ def state_machine(request: HttpRequest) -> HttpResponse:
     )
 
 
+@login_required
 def dialog(request: HttpRequest) -> HttpResponse:
     """Triggers a chan."""
     event = request.POST.get("event", None)
@@ -47,6 +48,7 @@ def dialog(request: HttpRequest) -> HttpResponse:
     # TODO: Remove this once the controller is implemented
     state = request.POST.get("current_state", "None")
 
+    # TODO: Remove this and pull the arguments from the controller, once implemented
     args = ["arg1", "arg2", "arg3"]
 
     context = dict(

--- a/controller/views/partials.py
+++ b/controller/views/partials.py
@@ -1,5 +1,7 @@
 """Partial views module for the controller app."""
 
+from typing import Any
+
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
@@ -10,15 +12,20 @@ from ..tables import FSMTable
 
 @login_required
 def state_machine(request: HttpRequest) -> HttpResponse:
-    """Triggers a chan."""
+    """Renders the state machine view."""
     event = request.POST.get("event", None)
+    kwargs: dict[str, Any] = {  # type: ignore[misc]
+        k: v
+        for k, v in request.POST.items()
+        if k not in ["csrfmiddlewaretoken", "event", "current_state"]
+    }
 
     # TODO: Remove this once the controller is implemented
     state = request.POST.get("current_state", "None")
 
     fsm = DruncFSM.get(state)
     if event:
-        fsm.send(event)
+        fsm.send(event, **kwargs)
 
     table = FSMTable.from_dict(fsm.to_dict(), fsm.current_state.name)
 
@@ -30,4 +37,26 @@ def state_machine(request: HttpRequest) -> HttpResponse:
             table=table,
         ),
         template_name="controller/partials/state_machine.html",
+    )
+
+
+def dialog(request: HttpRequest) -> HttpResponse:
+    """Triggers a chan."""
+    event = request.POST.get("event", None)
+
+    # TODO: Remove this once the controller is implemented
+    state = request.POST.get("current_state", "None")
+
+    args = ["arg1", "arg2", "arg3"]
+
+    context = dict(
+        current_state=state,
+        event=event,
+        args=args,
+    )
+
+    return render(
+        request=request,
+        context=context,
+        template_name="controller/partials/arguments_dialog.html",
     )

--- a/tests/controller/test_tables.py
+++ b/tests/controller/test_tables.py
@@ -34,7 +34,7 @@ def test_toggle_button_current(mocker):
     assert (
         result
         == (
-            "<button hx-post=/mocked_url/ hx-target='#state-machine' hx-include='#event_event' "  # noqa: E501
+            "<button hx-post=/mocked_url/ hx-target='#htmx-dialog-container' hx-include='#event_event' "  # noqa: E501
             "class='btn btn-success w-100 mx-2' >event</button>"
         )
     )

--- a/tests/controller/views/test_partial_views.py
+++ b/tests/controller/views/test_partial_views.py
@@ -40,3 +40,55 @@ class TestFSMView(LoginRequiredTest):
         assert response.context["events"] == [
             t.event for t in DruncFSM.get(event.target.name).current_state.transitions
         ]
+
+    def test_post_with_arguments(self, auth_client, mocker):
+        """Tests basic calls of view method."""
+        mock_send = mocker.patch("controller.views.partials.DruncFSM.send")
+
+        auth_client.post(
+            self.endpoint,
+            data={
+                "event": "",
+                "current_state": "none",
+                "arg1": "value1",
+                "arg2": "value2",
+            },
+        )
+        mock_send.assert_not_called()
+
+        auth_client.post(
+            self.endpoint,
+            data={
+                "event": "event",
+                "current_state": "none",
+                "arg1": "value1",
+                "arg2": "value2",
+            },
+        )
+        mock_send.assert_called_once_with("event", arg1="value1", arg2="value2")
+
+
+class TestDialogView(LoginRequiredTest):
+    """Test the process_manager.views.process_table view function."""
+
+    endpoint = reverse("controller:dialog")
+
+    def test_empty_post(self, auth_client):
+        """Tests basic calls of view method."""
+        response = auth_client.post(self.endpoint)
+        assert response.status_code == HTTPStatus.OK
+        assert response.context["current_state"] == "None"
+        assert response.context["event"] is None
+        assert response.context["args"] == ["arg1", "arg2", "arg3"]
+
+    def test_non_empty_post(self, auth_client):
+        """Tests basic calls of view method."""
+        event = "turn_left"
+        state = "confused"
+        response = auth_client.post(
+            self.endpoint, data={"event": event, "current_state": state}
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.context["current_state"] == state
+        assert response.context["event"] == event
+        assert response.context["args"] == ["arg1", "arg2", "arg3"]


### PR DESCRIPTION
# Description

Adds a pop-up window to enable the input of the parameters required to execute the transitions in the FSM. For now, this is just a placeholder, front end focused. In the final implementation, the required arguments will be pulled from the controller FSM and there might be transitions that do not require arguments, which will also be taken into account. 

https://github.com/user-attachments/assets/e441a258-b691-43f7-b4c3-27e7b0f80789

Fixes #216 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
