### PR TITLE
Enable using lr-session config with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ docker compose exec drunc /entrypoint.sh drunc-controller-shell grpc://localhost
 For details of working with the controller see the [drunc wiki]. You should also be able
 to see the booted processes in the Process Manager UI.
 
+#### Note for MacOS users
+
+The above `boot_test_session.sh` will not work on M-series Macs because of limitations
+with the x86 architecture emulation used by MacOS. There is a simpler configuration that
+can be used instead. To use this, set the following environment variables before
+starting the docker containers:
+
+- `CSC_SESSION=lr-session`
+- `CSC_URL=drunc:25000`
+
 [drunc wiki]: https://github.com/DUNE-DAQ/drunc/wiki/Controller
 
 ## Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - db:/usr/src/app/db
     environment:
       - PROCESS_MANAGER_URL=drunc:10054
+      - CSC_URL
+      - CSC_SESSION
   drunc:
     build: ./drunc_docker_service/
     profiles:
@@ -26,6 +28,8 @@ services:
         drunc-process-manager --log-level debug /process-manager-kafka.json 10054
     expose:
       - 10054
+    environment:
+      - CSC_SESSION
     depends_on:
       kafka:
         condition: service_healthy

--- a/drunc_docker_service/boot_test_session.sh
+++ b/drunc_docker_service/boot_test_session.sh
@@ -4,4 +4,12 @@
 . /basedir/NFD_DEV_241114_A9/env.sh
 
 # boot full test session
-drunc-process-manager-shell grpc://localhost:10054 boot config/daqsystemtest/example-configs.data.xml local-2x3-config
+if [[ "$CSC_SESSION" == "lr-session" ]]; then
+    CONFIG="config/lrSession.data.xml"
+    SESSION=$CSC_SESSION
+else
+    CONFIG="config/daqsystemtest/example-configs.data.xml"
+    SESSION="local-2x3-config"
+fi
+
+drunc-process-manager-shell grpc://localhost:10054 boot $CONFIG $SESSION


### PR DESCRIPTION
# Description

This PR enables using the more minimal "lr-session" configuration for running the controllers, this is because the full example currently used cannot run on ARM processors (ie Macs), even with x86 emulation.

I've tested this on my Mac and it works, albeit with some limitations in viewing the FSM.

This PR is currently based off the `controller_interface` branch (PR #193), I think it should wait to be merged into `main` until after that is merged.

Fixes #239 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
