### PR TITLE
Fixes bug in test_get_with_search

### DIFF
--- a/tests/process_manager/views/test_partial_views.py
+++ b/tests/process_manager/views/test_partial_views.py
@@ -33,7 +33,7 @@ class TestProcessTableView(LoginRequiredTest):
         sessions = sessions or [f"session{i}" for i in range(len(uuids))]
         for instance_mock, uuid, session in zip(instance_mocks, uuids, sessions):
             instance_mock.uuid.uuid = str(uuid)
-            instance_mock.session = session
+            instance_mock.process_description.metadata.session = session
             instance_mock.status_code = 0
         mock().data.values.__iter__.return_value = instance_mocks
         return mock
@@ -47,7 +47,7 @@ class TestProcessTableView(LoginRequiredTest):
         assert response.status_code == HTTPStatus.OK
         table = response.context["table"]
         assert isinstance(table, ProcessTable)
-        for row, uuid in zip(table.data.data, uuids):
+        for row, uuid in zip(table.data.data, uuids[1:4]):
             assert row["uuid"] == uuid
             assert row["session"] == "session2"
 


### PR DESCRIPTION
# Description

This PR fixes a bug in the `test_get_with_search` test, where `table_data` in the `process_table` view was not being update correctly due to incorrect mocking of the session data. The mock for `get_session_info` now correctly simulates the "session" info, and the test has been updated to properly verify the filtered data.

Fixes #155

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
