### PR TITLE
:bug: Manually add SIGHUP attr during tests.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,7 @@
 """Unit tests for drunc_ui."""
+import platform
+import signal
+
+# Windows does not have SIGHUP, so we define it here to avoid errors during tests
+if platform.system() == 'Windows':
+    signal.SIGHUP = 1  # type: ignore[attr-defined]


### PR DESCRIPTION
# Description

Conditionally adds `SIGHUP` attribute to the `signal` module when running tests in Windows. Apparently, it was removed in Python 3.7 from the Windows version. I don't know if this hack is also needed in MacOS. If it is, it should be easy to fix.

More info in https://stackoverflow.com/a/65906782/3778792

Fixes # N/A

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
