### PR TITLE
Consolidate use of nightly tag in docker image

### DIFF
--- a/drunc_docker_service/Dockerfile
+++ b/drunc_docker_service/Dockerfile
@@ -6,19 +6,20 @@ RUN yum install -y openssh-server && yum clean all
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /basedir
+ENV NIGHTLY_TAG=NFD_DEV_241114_A9
 
 # setup for the the dune development environment that provides the full set of
 # dependencies required for booting of the controller test session
 # See https://github.com/DUNE-DAQ/drunc/wiki/Setup-drunc-with-DUNE-DAQ for explanation
-ENV SPACK_ROOT /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD_DEV_241114_A9/spack-0.22.0
+ENV SPACK_ROOT /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG/spack-0.22.0
 RUN source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh && \
-        setup_dbt latest_v5 && \
-        dbt-create -n NFD_DEV_241114_A9 && \
-        cd NFD_DEV_241114_A9 && \
-        source env.sh && \
-        dbt-build && \
-        dbt-workarea-env
-WORKDIR /basedir/NFD_DEV_241114_A9/
+    setup_dbt latest_v5 && \
+    dbt-create -n "$NIGHTLY_TAG" && \
+    cd "$NIGHTLY_TAG" && \
+    source env.sh && \
+    dbt-build && \
+    dbt-workarea-env
+WORKDIR /basedir/$NIGHTLY_TAG/
 
 COPY process-manager-kafka.json /
 

--- a/drunc_docker_service/boot_test_session.sh
+++ b/drunc_docker_service/boot_test_session.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# setup dunedaq environment
-. /basedir/NFD_DEV_241114_A9/env.sh
-
 # boot full test session
 if [[ "$CSC_SESSION" == "lr-session" ]]; then
     CONFIG="config/lrSession.data.xml"
@@ -12,4 +9,4 @@ else
     SESSION="local-2x3-config"
 fi
 
-drunc-process-manager-shell grpc://localhost:10054 boot $CONFIG $SESSION
+/entrypoint.sh drunc-process-manager-shell grpc://localhost:10054 boot $CONFIG $SESSION

--- a/drunc_docker_service/entrypoint.sh
+++ b/drunc_docker_service/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # setup dunedaq environment
-. /basedir/NFD_DEV_241114_A9/env.sh
+. /basedir/"$NIGHTLY_TAG"/env.sh
 
 exec "$@"


### PR DESCRIPTION
# Description

This PR removes some of the duplication of the version tag used by the nightly images. This will simplify updates as it will only have to be changed in one place.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
