### PR TITLE
♻ Add a more robust way of getting controller URL.

### DIFF
--- a/controller/controller_interface.py
+++ b/controller/controller_interface.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from drunc.connectivity_service.client import ConnectivityServiceClient
 from drunc.controller.controller_driver import ControllerDriver
 from drunc.utils.shell_utils import create_dummy_token_from_uname
-from drunc.utils.utils import get_control_type_and_uri_from_connectivity_service
 from druncschema.request_response_pb2 import Description
 
 
@@ -18,11 +17,13 @@ def get_controller_uri() -> str:
         str: The URI of the root controller.
     """
     csc = ConnectivityServiceClient(settings.CSC_SESSION, settings.CSC_URL)
-    _, uri = get_control_type_and_uri_from_connectivity_service(
-        csc,
-        name="root-controller",
-    )
-    return uri
+    uris = csc.resolve("root-controller_control", "RunControlMessage")
+    if len(uris) != 1:
+        raise ValueError(
+            f"Expected 1 URI for root-controller, found {len(uris)}: {uris}"
+        )
+
+    return uris[0]["uri"].removeprefix("grpc://")
 
 
 def get_controller_driver() -> ControllerDriver:


### PR DESCRIPTION
# Description

Replaces the way we get the Copntroller uri with a more robust approach. After https://github.com/ImperialCollegeLondon/drunc_ui/pull/258#discussion_r1869934336 comment made by Chris

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
