### PR TITLE
Use 1x1 config as default session

### DIFF
--- a/drunc_docker_service/boot_test_session.sh
+++ b/drunc_docker_service/boot_test_session.sh
@@ -9,7 +9,7 @@ if [[ "$CSC_SESSION" == "lr-session" ]]; then
     SESSION=$CSC_SESSION
 else
     CONFIG="config/daqsystemtest/example-configs.data.xml"
-    SESSION="local-2x3-config"
+    SESSION="local-1x1-config"
 fi
 
 drunc-process-manager-shell grpc://localhost:10054 boot $CONFIG $SESSION

--- a/drunc_ui/settings/settings.py
+++ b/drunc_ui/settings/settings.py
@@ -148,7 +148,7 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 
 PROCESS_MANAGER_URL = os.getenv("PROCESS_MANAGER_URL", "localhost:10054")
 CSC_URL = os.getenv("CSC_URL", "drunc:5000")
-CSC_SESSION = os.getenv("CSC_SESSION", "local-2x3-config")
+CSC_SESSION = os.getenv("CSC_SESSION", "local-1x1-config")
 
 INSTALLED_APPS += ["crispy_forms", "crispy_bootstrap5"]
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"


### PR DESCRIPTION
# Description

Configures a new default session (`1x1`). In terms of complexity this is somewhere between the current default (`2x3`) and the lightweight (`lr-session`) options. The advantage of this configuration over `lr-session` is that it has required arguments for the state transitions.

Based the branch off of `tree-table` for ease of testing. I've tried this on Linux a couple of times without issue. Please could you try this out (with the full set of FSM transitions) on the various different platforms - M1 Mac, Intel Mac and Windows. It will likely still not work on M1 Mac due to the known issue with the AVX instruction set emulation.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
