### PR TITLE
:heavy_plus_sign: Update nightly build.

### DIFF
--- a/drunc_docker_service/Dockerfile
+++ b/drunc_docker_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/imperialcollegelondon/dunedaq_dev_environment:nightly-241114
+FROM ghcr.io/imperialcollegelondon/dunedaq_dev_environment:nightly-241206
 
 RUN yum install -y openssh-server && yum clean all
 
@@ -6,7 +6,7 @@ RUN yum install -y openssh-server && yum clean all
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /basedir
-ENV NIGHTLY_TAG=NFD_DEV_241114_A9
+ENV NIGHTLY_TAG=NFD_DEV_241206_A9
 
 # setup for the the dune development environment that provides the full set of
 # dependencies required for booting of the controller test session

--- a/poetry.lock
+++ b/poetry.lock
@@ -504,14 +504,14 @@ develop = false
 
 [package.dependencies]
 click = "*"
-click-shell = "*"
+click_shell = "*"
 googleapis-common-protos = "*"
 grpcio = "*"
 grpcio-status = "*"
-grpcio-tools = "*"
+grpcio_tools = "*"
 gunicorn = "*"
 kafka-python = "*"
-nest-asyncio = "*"
+nest_asyncio = "*"
 rich = "*"
 sh = "*"
 
@@ -521,8 +521,8 @@ develop = ["ipdb", "ipython"]
 [package.source]
 type = "git"
 url = "https://github.com/DUNE-DAQ/drunc.git"
-reference = "f068eaccb840da03a104adba2da3f27454c218d5"
-resolved_reference = "f068eaccb840da03a104adba2da3f27454c218d5"
+reference = "1848d8494d5583e1a551134d3cd3a38aea810cd0"
+resolved_reference = "1848d8494d5583e1a551134d3cd3a38aea810cd0"
 
 [[package]]
 name = "druncschema"
@@ -537,7 +537,7 @@ develop = false
 googleapis-common-protos = "*"
 grpcio = "*"
 grpcio-status = "*"
-grpcio-tools = "*"
+grpcio_tools = "*"
 
 [package.extras]
 develop = ["ipdb", "ipython"]
@@ -545,8 +545,8 @@ develop = ["ipdb", "ipython"]
 [package.source]
 type = "git"
 url = "https://github.com/DUNE-DAQ/druncschema.git"
-reference = "a07226fa9c3a4329b4c38e084c913cb1e2db0b4e"
-resolved_reference = "a07226fa9c3a4329b4c38e084c913cb1e2db0b4e"
+reference = "91dbf64ef91c31df9fc1d2872d07f484880e5921"
+resolved_reference = "91dbf64ef91c31df9fc1d2872d07f484880e5921"
 
 [[package]]
 name = "editorconfig"
@@ -2007,4 +2007,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "4cd3ff7a5ce8f7f5e8d9a92be5fabf05be871326d2527c00f7358e5eede99efe"
+content-hash = "7430f82a52e1a4c4c61a334751739130680ec5717c279df4e2d74976c34ab48c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ authors = [
 python = "~3.11"
 django = "^5.1"
 whitenoise = "^6.8.2"
-drunc = { git = "https://github.com/DUNE-DAQ/drunc.git", rev = "f068eaccb840da03a104adba2da3f27454c218d5" }
-druncschema = { git = "https://github.com/DUNE-DAQ/druncschema.git", rev = "a07226fa9c3a4329b4c38e084c913cb1e2db0b4e" }
+drunc = { git = "https://github.com/DUNE-DAQ/drunc.git", rev = "1848d8494d5583e1a551134d3cd3a38aea810cd0" }
+druncschema = { git = "https://github.com/DUNE-DAQ/druncschema.git", rev = "91dbf64ef91c31df9fc1d2872d07f484880e5921" }
 django-tables2 = "^2.7.0"
 django-bootstrap5 = "^24.3"
 pytest-asyncio = "^0.24.0"


### PR DESCRIPTION
# Description

Updates the toolchain to use the latests build. Full FSM transitions checked with the 3x2 session and all works well. 

@cc-a , I have not been able to push the image. It seems I don't have permission:

```
$ docker push ghcr.io/imperialcollegelondon/dunedaq_dev_environment:nightly-241206
The push refers to repository [ghcr.io/imperialcollegelondon/dunedaq_dev_environment]
8ae95998f49d: Mounted from dune-daq/nightly-release-alma9
f63f1936965b: Layer already exists
3cd9fe739794: Layer already exists
e6af6818f364: Layer already exists
091bc31a89f9: Layer already exists
d4adf5833eb5: Layer already exists
d3946c2c30c4: Layer already exists
2c0f509ddf62: Layer already exists
e5ed9aa86034: Layer already exists
676603971c24: Layer already exists
6e00cbb361f2: Layer already exists
3c6277f50413: Layer already exists
a556727f0c1b: Layer already exists
354523db755e: Layer already exists
unauthorized: unauthenticated: User cannot be authenticated with the token provided.
```

Do you need to authorize me or something?

Fixes # N/A

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
