### PR TITLE
ERS logs page

### DIFF
--- a/controller/templates/controller/ers_logs.html
+++ b/controller/templates/controller/ers_logs.html
@@ -1,0 +1,32 @@
+{% extends "main/base.html" %}
+{% block title %}
+  Controller - ERS Logs
+{% endblock title %}
+{% block extra_css %}
+  <style>
+    #hide-messages-button {
+      filter: invert(1);
+      float: right;
+    }
+    .message-item {
+      font-family: 'Arial', sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.4;
+    }
+    .flex-container {
+      display: flex;
+      gap: 15px;
+    }
+    .flex-container .fsm-panel {
+      flex: 1;
+    }
+    .flex-container .message-panel {
+      width: 100%;
+    }
+  </style>
+{% endblock extra_css %}
+{% block content %}
+  <div class="container-fluid no-padding no-margin">
+    <div class="flex-container" id="main-content">{% include "main/messages.html" with topic="ERS" %}</div>
+  </div>
+{% endblock content %}

--- a/controller/urls.py
+++ b/controller/urls.py
@@ -16,5 +16,6 @@ partial_urlpatterns = [
 urlpatterns = [
     path("", pages.index, name="index"),
     path("app_tree", pages.app_tree_view, name="app_tree"),
+    path("ers_logs", pages.ers_logs, name="ers_logs"),
     path("partials/", include(partial_urlpatterns)),
 ]

--- a/controller/views/pages.py
+++ b/controller/views/pages.py
@@ -18,3 +18,9 @@ def app_tree_view(request: HttpRequest) -> HttpResponse:
         request=request,
         template_name="controller/app_tree_view.html",
     )
+
+
+@login_required
+def ers_logs(request: HttpRequest) -> HttpResponse:
+    """View that renders the ERS log messages page."""
+    return render(request=request, template_name="controller/ers_logs.html")

--- a/drunc_ui/settings/settings.py
+++ b/drunc_ui/settings/settings.py
@@ -157,8 +157,6 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 KAFKA_ADDRESS = os.getenv("KAFKA_ADDRESS", "kafka:9092")
 
 KAFKA_TOPIC_REGEX = {
-    # ALL matches all topics.
-    "ALL": "^.*$",
     # PROCMAN matches topics of the form "control.<session>.process_manager".
     "PROCMAN": "^control\..+\.process_manager$",
     # ERS matches only the topic "erskafka-reporting".

--- a/main/templates/main/messages.html
+++ b/main/templates/main/messages.html
@@ -20,14 +20,14 @@
                type="search"
                name="search"
                placeholder="Search messages..."
-               hx-get="{% url 'main:messages' topic|default:"ALL" %}"
+               hx-get="{% url 'main:messages' topic %}"
                hx-trigger="input changed delay:500ms, every 1s"
                hx-target="#message-list"
                hx-include="#filter-form">
         <!-- Severity Filter Dropdown -->
         <select name="severity"
                 class="form-select mb-2"
-                hx-get="{% url 'main:messages' topic|default:"ALL" %}"
+                hx-get="{% url 'main:messages' topic %}"
                 hx-target="#message-list"
                 hx-include="#filter-form">
           <option value="">All Severities</option>
@@ -39,7 +39,7 @@
       </form>
       <div id="message-list"
            class="list-group"
-           hx-get="{% url 'main:messages' topic|default:"ALL" %}"
+           hx-get="{% url 'main:messages' topic %}"
            hx-trigger="load"></div>
     </div>
   </div>


### PR DESCRIPTION
# Description

Add a simple view for displaying `erskafka-reporting` messages. Just uses the modular messages panel with the ERS topic, as in the main controller page.

Also remove the default `ALL` topic for the message panel. Not needed, and is causing problems.

Fixes #166 
Fixes #168 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
