### PR TITLE
Add dummy functions to get sessions and configs

### DIFF
--- a/interfaces/controller_interface.py
+++ b/interfaces/controller_interface.py
@@ -187,8 +187,8 @@ def get_sessions() -> list[dict[str, str]]:
     relevant endpoint is implemented.
 
     Returns:
-        List of dictionaries indicating the session name and the actor name (i.e. the
-        user who boots the session).
+        List of dictionaries indicating the session name and the actor name (i.e.
+        typically, the user who boots the session).
     """
     import random
     import uuid

--- a/interfaces/controller_interface.py
+++ b/interfaces/controller_interface.py
@@ -178,3 +178,26 @@ def get_configs() -> list[dict[str, str]]:
             "id": "local-2x3-config",
         },
     ]
+
+
+def get_sessions() -> list[dict[str, str]]:
+    """Get the active sessions in the controller.
+
+    TODO: Placeholder function with random values. Pull data dynamically when the
+    relevant endpoint is implemented.
+
+    Returns:
+        List of dictionaries indicating the session name and the actor name (i.e. the
+        user who boots the session).
+    """
+    import random
+    import uuid
+
+    actors = ["Alice", "Bob", "Gandalf"]
+    return [
+        {
+            "name": uuid.uuid4().hex,
+            "actor": random.choice(actors),
+        }
+        for _ in range(random.randint(4, 10))
+    ]

--- a/interfaces/controller_interface.py
+++ b/interfaces/controller_interface.py
@@ -148,3 +148,33 @@ def get_detectors(description: Description | None = None) -> dict[str, str]:
             detectors.update(get_detectors(child))
 
     return detectors
+
+
+def get_configs() -> list[dict[str, str]]:
+    """Get the available configurations for the controller.
+
+    TODO: Placeholder function with hardcoded values. Pull data dynamically when the
+    relevant endpoint is implemented.
+
+    Returns:
+        List of dictionaries indicating the file where the config is contained and the
+        id for the config.
+    """
+    return [
+        {
+            "file": "example-configs.data.xml",
+            "id": "ehn1-local-1x1-config",
+        },
+        {
+            "file": "example-configs.data.xml",
+            "id": "ehn1-local-2x3-config",
+        },
+        {
+            "file": "example-configs.data.xml",
+            "id": "local-1x1-config",
+        },
+        {
+            "file": "example-configs.data.xml",
+            "id": "local-2x3-config",
+        },
+    ]

--- a/tests/interfaces/test_controller_interface.py
+++ b/tests/interfaces/test_controller_interface.py
@@ -221,3 +221,11 @@ def test_get_detectors(mocker):
     mock_controller().describe.return_value = root_status_with_none_child
     result = get_detectors()
     assert result == {"root": ""}
+
+
+def test_get_configs():
+    """Test the get_configs function."""
+    from interfaces.controller_interface import get_configs
+
+    configs = get_configs()
+    assert all("file" in config.keys() and "id" in config.keys() for config in configs)

--- a/tests/interfaces/test_controller_interface.py
+++ b/tests/interfaces/test_controller_interface.py
@@ -229,3 +229,13 @@ def test_get_configs():
 
     configs = get_configs()
     assert all("file" in config.keys() and "id" in config.keys() for config in configs)
+
+
+def test_get_sessions():
+    """Test the get_sessions function."""
+    from interfaces.controller_interface import get_sessions
+
+    sessions = get_sessions()
+    assert all(
+        "name" in session.keys() and "actor" in session.keys() for session in sessions
+    )


### PR DESCRIPTION
# Description

These are placeholder functions needed to implement the front end in a meaningful way, currently containign random or hardcoded values. They will need to be replaced eventually to pull this data dynamically, once the relevant endpoint is implemented.

Fixes #320 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
