### PR TITLE
Session manager should not by async

### DIFF
--- a/interfaces/session_manager_interface.py
+++ b/interfaces/session_manager_interface.py
@@ -9,7 +9,7 @@ def get_session_manager_driver() -> SessionManagerDriver:
     """Get a ProcessManagerDriver instance."""
     token = create_dummy_token_from_uname()
     return SessionManagerDriver(
-        settings.SESSION_MANAGER_URL, token=token, aio_channel=True
+        settings.SESSION_MANAGER_URL, token=token, aio_channel=False
     )
 
 


### PR DESCRIPTION
# Description

Bug: session manager is not async, so set the right flag (async=False).

Fixes #414 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
