### PR TITLE
Run tests with the develop version of `drunc` and `druncschema`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '* 5 * * 1' # every Monday at 5:00 UTC
 
 jobs:
   test:
@@ -27,6 +29,12 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
+
+      - name: Install latest drunc and druncschema
+        if: github.event_name == 'schedule'
+        run: |
+          pip install git+https://github.com/DUNE-DAQ/druncschema.git@develop
+          pip install git+https://github.com/DUNE-DAQ/drunc.git@develop
 
       - name: Test building the docs
         run: poetry run mkdocs build --strict


### PR DESCRIPTION
# Description

The goal is to find out when `drunc_ui` stops being compatible with `drunc` and `druncschema` for whatever reason, so corrective actions at either end can be implemented.

The way this works is by running the whole test suite automatically once a week but using the develop versions of `drunc` and `druncschema`. [Based on how GitHub features on notifications work now](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/notifications-for-workflow-runs), only me will receive a notification if the workflow fails. Not ideal, but maybe good enough for now. 

Fixes #392 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
