### PR TITLE
:construction_worker: Add schedule test with Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version:
-          - ${{ inputs.python_version }}
+        python-version: ${{ inputs.python_version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      python_version:
+        description: Python version to use in the workflow
+        default: '3.10'
+        required: true
+        type: string
   schedule:
     - cron: '* 5 * * 0' # every Sunday at 5:00 UTC
 
@@ -16,7 +23,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: ['3.10']
+        python-version:
+          - ${{ inputs.python_version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: ${{ inputs.python_version }}
+        python-version: ['${{ inputs.python_version }}']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,20 @@
 name: Test and build
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
   workflow_call:
     inputs:
       python_version:
         description: Python version to use in the workflow
         default: '3.10'
-        required: true
         type: string
-  schedule:
-    - cron: '* 5 * * 0' # every Sunday at 5:00 UTC
+      use_develop:
+        description: If develop versions of drunc and druncschema should be used
+        default: false
+        type: boolean
 
 jobs:
   test:
-    runs-on: ${{matrix.os}}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        python-version: ['${{ inputs.python_version }}']
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -31,14 +22,14 @@ jobs:
         run: pipx install poetry==1.8.4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{matrix.python-version}}
+          python-version: ${{ inputs.python_version }}
           cache: poetry
 
       - name: Install dependencies
         run: poetry install
 
       - name: Install latest drunc and druncschema
-        if: github.event_name == 'schedule'
+        if: ${{ inputs.use_develop }}
         run: |
           pip install git+https://github.com/DUNE-DAQ/druncschema.git@develop
           pip install git+https://github.com/DUNE-DAQ/drunc.git@develop

--- a/.github/workflows/current_ci.yml
+++ b/.github/workflows/current_ci.yml
@@ -1,6 +1,9 @@
 name: Test in Python 3.11
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '* 5 * * 0' # every Sunday at 5:00 UTC
@@ -9,5 +12,5 @@ jobs:
   test:
     uses: ./.github/workflows/ci.yml
     with:
-      python_version: '3.11'
-      use_develop: false
+      python_version: '3.10'
+      use_develop: github.event_name == 'schedule'

--- a/.github/workflows/current_ci.yml
+++ b/.github/workflows/current_ci.yml
@@ -13,4 +13,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       python_version: '3.10'
-      use_develop: github.event_name == 'schedule'
+      use_develop: ${{ github.event_name }}  == 'schedule'

--- a/.github/workflows/future_ci.yml
+++ b/.github/workflows/future_ci.yml
@@ -1,4 +1,4 @@
-name: Test in Python 3.11
+name: Test in develop
 
 on:
   workflow_dispatch:
@@ -10,4 +10,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       python_version: '3.11'
-      use_develop: false
+      use_develop: true

--- a/.github/workflows/future_ci.yml
+++ b/.github/workflows/future_ci.yml
@@ -1,0 +1,12 @@
+name: Test in Python 3.11
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '* 5 * * 0' # every Sunday at 5:00 UTC
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+    with:
+      python_version: '3.11'

--- a/.github/workflows/stable_ci.yml
+++ b/.github/workflows/stable_ci.yml
@@ -1,16 +1,14 @@
-name: Test in Python 3.11
+name: Test in stable
 
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: '* 5 * * 0' # every Sunday at 5:00 UTC
 
 jobs:
   test:
     uses: ./.github/workflows/ci.yml
     with:
       python_version: '3.10'
-      use_develop: ${{ github.event_name }}  == 'schedule'
+      use_develop: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.11"
+python = ">=3.10,<3.12"
 django = "^5.2"
 whitenoise = "^6.9.0"
 drunc = { git = "https://github.com/DUNE-DAQ/drunc.git", rev = "d411037139c52554bb2d1db307d520d1184d4e96" }


### PR DESCRIPTION
# Description

Create a separate workflow that runs the tests using Python 3.11 occasionally, checking that all works - or will work - in future versions of Python. 

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
