### PR TITLE
475 boot button

### DIFF
--- a/drunc_docker_service/process-manager-kafka.json
+++ b/drunc_docker_service/process-manager-kafka.json
@@ -14,8 +14,8 @@
         "path": "./info.json",
         "type": "file"
     },
-    "opmon_conf":{
+    "opmon_conf": {
         "level": "info",
-        "interval_s" : 10.0
+        "interval_s": 10.0
     }
 }

--- a/session_manager/tables.py
+++ b/session_manager/tables.py
@@ -63,9 +63,9 @@ class ActiveSessions(tables.Table):
     def render_select(self, value: str) -> str:
         """Customize behavior of checkboxes in the select column."""
         return mark_safe(
-            f'<input type="checkbox" name="select" value="{value}" '
+            f'<input type="radio" name="select session" value="{value}" '
             f'id="{value}-input" hx-preserve="true" '
-            'class="form-check-input form-check-input-lg row-checkbox" '
+            'class="form-check-input form-check-input-lg session-checkbox" '
             'style="transform: scale(1.5);" '
         )
 
@@ -95,6 +95,18 @@ class AvailableConfigs(tables.Table):
         },
     )
 
+    select = LabelledCheckBoxColumn(
+        accessor="file",
+        orderable=False,
+        verbose_name="Select",
+        attrs={
+            "th": {"class": "header-style small-text"},
+            "td__input": {
+                "class": "form-check-input form-check-input-lg text-center",
+            },
+        },
+    )
+
     class Meta:
         """Table meta options for rendering behaviour and styling."""
 
@@ -102,3 +114,12 @@ class AvailableConfigs(tables.Table):
         attrs: ClassVar[dict[str, str]] = {
             "class": "table table-hover table-responsive small-text",
         }
+
+    def render_select(self, value: str) -> str:
+        """Customize behavior of checkboxes in the select column."""
+        return mark_safe(
+            f'<input type="radio" name="select config" value="{value}" '
+            f'id="{value}-input" hx-preserve="true" '
+            'class="form-check-input form-check-input-lg config-checkbox" '
+            'style="transform: scale(1.5);" '
+        )

--- a/session_manager/templates/session_manager/index.html
+++ b/session_manager/templates/session_manager/index.html
@@ -107,14 +107,15 @@
             <h5>Available configurations</h5>
           </div>
           <div class="card-body">
-            <div class="d-flex justify-content-between mb-3"></div>
-            <input type="submit"
-                   value="Boot session"
-                   class="btn btn-success w-100 mx-2"
-                   name="action"
-                   onclick="return confirm('Boot session based on the selected configuration?')"
-                   disabled
-                   _="install disableActionButtonConfig">
+            <div class="d-flex justify-content-between mb-3">
+              <input type="submit"
+                     value="Boot session"
+                     class="btn btn-success w-100 mx-2"
+                     name="action"
+                     onclick="return confirm('Boot session based on the selected configuration?')"
+                     disabled
+                     _="install disableActionButtonConfig">
+            </div>
           </div>
           <div hx-get="{% url 'session_manager:available_config_table' %}"
                hx-trigger="load, every 1s"

--- a/session_manager/templates/session_manager/index.html
+++ b/session_manager/templates/session_manager/index.html
@@ -107,6 +107,7 @@
             <h5>Available configurations</h5>
           </div>
           <div class="card-body">
+            <div class="d-flex justify-content-between mb-3"></div>
             <input type="submit"
                    value="Boot session"
                    class="btn btn-success w-100 mx-2"

--- a/session_manager/templates/session_manager/index.html
+++ b/session_manager/templates/session_manager/index.html
@@ -56,9 +56,17 @@
 {% endblock extra_css %}
 {% block extra_js %}
   <script type="text/hyperscript">
-    behavior disableActionButton
-      on click[target.matches('.row-checkbox')] from elsewhere
-        if <.row-checkbox:checked /> is empty
+    behavior disableActionButtonSession
+      on click[target.matches('.session-checkbox')] from elsewhere
+        if <.session-checkbox:checked /> is empty
+          set me.disabled to true
+        else
+          set me.disabled to false
+      end
+    end
+    behavior disableActionButtonConfig
+      on click[target.matches('.config-checkbox')] from elsewhere
+        if <.config-checkbox:checked /> is empty
           set me.disabled to true
         else
           set me.disabled to false
@@ -83,7 +91,7 @@
                      name="action"
                      onclick="return confirm('Take control of selected session?')"
                      disabled
-                     _="install disableActionButton">
+                     _="install disableActionButtonSession">
             </div>
             <div hx-get="{% url 'session_manager:active_sessions_table' %}"
                  hx-trigger="load, every 1s"
@@ -99,11 +107,18 @@
             <h5>Available configurations</h5>
           </div>
           <div class="card-body">
-            <div hx-get="{% url 'session_manager:available_config_table' %}"
-                 hx-trigger="load, every 1s"
-                 hx-target="#available_config_table"></div>
-            <div id="available_config_table"></div>
+            <input type="submit"
+                   value="Boot session"
+                   class="btn btn-success w-100 mx-2"
+                   name="action"
+                   onclick="return confirm('Boot session based on the selected configuration?')"
+                   disabled
+                   _="install disableActionButtonConfig">
           </div>
+          <div hx-get="{% url 'session_manager:available_config_table' %}"
+               hx-trigger="load, every 1s"
+               hx-target="#available_config_table"></div>
+          <div id="available_config_table"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Adds a button to boot a session, which is enable only when a configuration is selected. I've used radio buttons rather than checkboxes because it would make sense to just boot a session at a time. I've changed the session take over button following the same pattern. 

Fixes #475 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
