### PR TITLE
:sparkles: Disable boot button if debug=False

### DIFF
--- a/process_manager/templates/process_manager/index.html
+++ b/process_manager/templates/process_manager/index.html
@@ -31,8 +31,11 @@
             <form method="post" action="{% url 'process_manager:process_action' %}">
               {% csrf_token %}
               <div class="d-flex justify-content-between mb-3">
-                <a href="{% url 'process_manager:boot_process' %}"
-                   class="btn btn-primary w-100 me-2">Boot</a>
+                {% if debug %}
+                  <!-- Only show boot button in debug mode -->
+                  <a href="{% url 'process_manager:boot_process' %}"
+                     class="btn btn-primary w-100 me-2">Boot</a>
+                {% endif %}
                 <input type="submit"
                        value="Restart"
                        class="btn btn-success w-100 mx-2"

--- a/process_manager/urls.py
+++ b/process_manager/urls.py
@@ -1,5 +1,6 @@
 """Urls module for the process_manager app."""
 
+from django.conf import settings
 from django.urls import include, path
 
 from .views import actions, pages, partials
@@ -14,6 +15,10 @@ urlpatterns = [
     path("", pages.index, name="index"),
     path("process_action/", actions.process_action, name="process_action"),
     path("logs/<uuid:uuid>", pages.logs, name="logs"),
-    path("boot_process/", pages.BootProcessView.as_view(), name="boot_process"),
     path("partials/", include(partial_urlpatterns)),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(
+        path("boot_process/", pages.BootProcessView.as_view(), name="boot_process")
+    )

--- a/process_manager/urls.py
+++ b/process_manager/urls.py
@@ -1,7 +1,7 @@
 """Urls module for the process_manager app."""
 
 from django.conf import settings
-from django.urls import include, path
+from django.urls import URLPattern, URLResolver, include, path
 
 from .views import actions, pages, partials
 
@@ -11,7 +11,7 @@ partial_urlpatterns = [
     path("process_table/", partials.process_table, name="process_table"),
 ]
 
-urlpatterns = [
+urlpatterns: list[URLPattern | URLResolver] = [
     path("", pages.index, name="index"),
     path("process_action/", actions.process_action, name="process_action"),
     path("logs/<uuid:uuid>", pages.logs, name="logs"),

--- a/process_manager/views/pages.py
+++ b/process_manager/views/pages.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import HttpRequest, HttpResponse
@@ -17,7 +18,11 @@ from ..forms import BootProcessForm
 @login_required
 def index(request: HttpRequest) -> HttpResponse:
     """View that renders the index/home page with process table."""
-    return render(request=request, template_name="process_manager/index.html")
+    return render(
+        request=request,
+        template_name="process_manager/index.html",
+        context={"debug": settings.DEBUG},
+    )
 
 
 @login_required

--- a/tests/process_manager/test_url.py
+++ b/tests/process_manager/test_url.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+
+class TestURLs(TestCase):
+    """Tests for the URLs in the process_manager app."""
+
+    def test_url_in_debug(self):
+        """Test that the boot_process URL is included when DEBUG is True."""
+        from process_manager import urls
+
+        with self.settings(DEBUG=True):
+            self.assertIn("boot_process", [url.name for url in urls.urlpatterns])
+
+        with self.settings(DEBUG=False):
+            self.assertNotIn("boot_process", [url.name for url in urls.urlpatterns])

--- a/tests/process_manager/test_url.py
+++ b/tests/process_manager/test_url.py
@@ -9,7 +9,11 @@ class TestURLs(TestCase):
         from process_manager import urls
 
         with self.settings(DEBUG=True):
-            self.assertIn("boot_process", [url.pattern for url in urls.urlpatterns])
+            self.assertIn(
+                "boot_process", [url.pattern.name for url in urls.urlpatterns]
+            )
 
         with self.settings(DEBUG=False):
-            self.assertNotIn("boot_process", [url.pattern for url in urls.urlpatterns])
+            self.assertNotIn(
+                "boot_process", [url.pattern.name for url in urls.urlpatterns]
+            )

--- a/tests/process_manager/test_url.py
+++ b/tests/process_manager/test_url.py
@@ -1,16 +1,13 @@
-from django.test import TestCase
+from django.urls import Resolver404, resolve
+from pytest import raises
 
 
-class TestURLs(TestCase):
-    """Tests for the URLs in the process_manager app."""
+def test_boot_process_url_not_available():
+    """Test that the boot_process URL is not included when DEBUG is False.
 
-    def test_boot_process_url_not_available(self):
-        """Test that the boot_process URL is not included when DEBUG is False.
-
-        NOTE That tests are always run with DEBUG=False regardless of the actual
-        setting, so this test is to ensure the view does not expose debug information
-        in production.
-        """
-        from process_manager import urls
-
-        self.assertNotIn("boot_process", [url.pattern.name for url in urls.urlpatterns])
+    NOTE That tests are always run with DEBUG=False regardless of the actual
+    setting, so this test is to ensure the view does not expose debug information
+    in production.
+    """
+    with raises(Resolver404):
+        resolve("process_manager:boot_process")

--- a/tests/process_manager/test_url.py
+++ b/tests/process_manager/test_url.py
@@ -9,7 +9,7 @@ class TestURLs(TestCase):
         from process_manager import urls
 
         with self.settings(DEBUG=True):
-            self.assertIn("boot_process", [url.name for url in urls.urlpatterns])
+            self.assertIn("boot_process", [url.pattern for url in urls.urlpatterns])
 
         with self.settings(DEBUG=False):
-            self.assertNotIn("boot_process", [url.name for url in urls.urlpatterns])
+            self.assertNotIn("boot_process", [url.pattern for url in urls.urlpatterns])

--- a/tests/process_manager/test_url.py
+++ b/tests/process_manager/test_url.py
@@ -4,16 +4,13 @@ from django.test import TestCase
 class TestURLs(TestCase):
     """Tests for the URLs in the process_manager app."""
 
-    def test_url_in_debug(self):
-        """Test that the boot_process URL is included when DEBUG is True."""
+    def test_boot_process_url_not_available(self):
+        """Test that the boot_process URL is not included when DEBUG is False.
+
+        NOTE That tests are always run with DEBUG=False regardless of the actual
+        setting, so this test is to ensure the view does not expose debug information
+        in production.
+        """
         from process_manager import urls
 
-        with self.settings(DEBUG=True):
-            self.assertIn(
-                "boot_process", [url.pattern.name for url in urls.urlpatterns]
-            )
-
-        with self.settings(DEBUG=False):
-            self.assertNotIn(
-                "boot_process", [url.pattern.name for url in urls.urlpatterns]
-            )
+        self.assertNotIn("boot_process", [url.pattern.name for url in urls.urlpatterns])

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -1,14 +1,14 @@
 from http import HTTPStatus
 from uuid import uuid4
 
-from django.test import TestCase
+from django.test import override_settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
 
 from ...utils import LoginRequiredTest, PermissionRequiredTest
 
 
-class TestIndexView(LoginRequiredTest, TestCase):
+class TestIndexView(LoginRequiredTest):
     """Tests for the index view."""
 
     endpoint = reverse("process_manager:index")
@@ -25,13 +25,15 @@ class TestIndexView(LoginRequiredTest, TestCase):
             f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
         )
 
-        with self.settings(DEBUG=False):
-            response = auth_client.get(self.endpoint)
-            assert not response.context["debug"]
-            assertNotContains(
-                response,
-                f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
-            )
+    @override_settings(DEBUG=False)
+    def test_debug_false(self, auth_client):
+        """Test the index view when DEBUG is False."""
+        response = auth_client.get(self.endpoint)
+        assert not response.context["debug"]
+        assertNotContains(
+            response,
+            f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
+        )
 
 
 class TestLogsView(PermissionRequiredTest):

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -1,13 +1,14 @@
 from http import HTTPStatus
 from uuid import uuid4
 
+from django.test import TestCase
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
 
 from ...utils import LoginRequiredTest, PermissionRequiredTest
 
 
-class TestIndexView(LoginRequiredTest):
+class TestIndexView(LoginRequiredTest, TestCase):
     """Tests for the index view."""
 
     endpoint = reverse("process_manager:index")

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -13,6 +13,7 @@ class TestIndexView(LoginRequiredTest):
 
     endpoint = reverse("process_manager:index")
 
+    @override_settings(DEBUG=True)
     def test_authenticated(self, auth_client):
         """Test the index view for an authenticated user."""
         with assertTemplateUsed(template_name="process_manager/index.html"):

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 from uuid import uuid4
 
-from django.test import override_settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
 
@@ -13,22 +12,19 @@ class TestIndexView(LoginRequiredTest):
 
     endpoint = reverse("process_manager:index")
 
-    @override_settings(DEBUG=True)
     def test_authenticated(self, auth_client):
         """Test the index view for an authenticated user."""
         with assertTemplateUsed(template_name="process_manager/index.html"):
             response = auth_client.get(self.endpoint)
         assert response.status_code == HTTPStatus.OK
 
-        assert response.context["debug"] is True
-        assertContains(
-            response,
-            f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
-        )
-
-    @override_settings(DEBUG=False)
     def test_debug_false(self, auth_client):
-        """Test the index view when DEBUG is False."""
+        """Test the index view when DEBUG is False.
+
+        NOTE That tests are always run with DEBUG=False regardless of the actual
+        setting, so this test is to ensure the view does not expose debug information
+        in production.
+        """
         response = auth_client.get(self.endpoint)
         assert not response.context["debug"]
         assertNotContains(

--- a/tests/process_manager/views/test_page_views.py
+++ b/tests/process_manager/views/test_page_views.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from uuid import uuid4
 
 from django.urls import reverse
-from pytest_django.asserts import assertContains, assertTemplateUsed
+from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
 
 from ...utils import LoginRequiredTest, PermissionRequiredTest
 
@@ -17,6 +17,20 @@ class TestIndexView(LoginRequiredTest):
         with assertTemplateUsed(template_name="process_manager/index.html"):
             response = auth_client.get(self.endpoint)
         assert response.status_code == HTTPStatus.OK
+
+        assert response.context["debug"] is True
+        assertContains(
+            response,
+            f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
+        )
+
+        with self.settings(DEBUG=False):
+            response = auth_client.get(self.endpoint)
+            assert not response.context["debug"]
+            assertNotContains(
+                response,
+                f'<a class="nav-link" href="{reverse("process_manager:boot_process")}">Boot</a>',  # noqa: E501
+            )
 
 
 class TestLogsView(PermissionRequiredTest):


### PR DESCRIPTION
# Description

Remove the "Boot" button on the `Process Manager` page when the tool runs in production - i.e. when `DEBUG=False` in the settings. 

I've tested this works and indeed the button is no longer there and the URL for booting sessions is not accessible, however that has revealed another issue (described in #513 )

Fixes #297

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
