### PR TITLE
JCF: add the same workflows as are currently available in drunc

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint with ruff
+
+on:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+      - run: ruff check --fix --exit-non-zero-on-fix
+      - run: ruff format
+

--- a/.github/workflows/run_mqst.yml
+++ b/.github/workflows/run_mqst.yml
@@ -1,0 +1,57 @@
+name: Run MQST
+
+on:
+  never-ever:
+
+jobs:
+  install_and_test:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: ghcr.io/dune-daq/nightly-release-alma9:development_v5
+
+    steps:
+      - name: Install SSH and run the daemon
+        run: |
+          dnf install openssh-server
+          dnf install openssh-clients
+          systemctl start sshd
+          systemctl enable sshd
+          ssh localhost echo "SSH is working"
+
+      - name: Set up dev nightly
+        run: |
+          mkdir nightly
+          cd nightly
+          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+          setup_dbt latest_v5
+          dbt-create -n last_fddaq
+          cd NFD_DEV*
+          source env.sh
+          dbt-build
+          dbt-workarea-env
+
+      - name: Install druncschema and drunc
+        run: |
+          cd nightly/NFD_DEV* || true
+          source env.sh
+          python -m pip install --upgrade pip
+          git clone https://github.com/DUNE-DAQ/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/DUNE-DAQ/drunc.git -b ${{ github.head_ref }}
+          cd druncschema
+          pip install .
+          cd -
+          cd drunc
+          pip install .
+          echo "DRUNC_DIR=$(pwd)" >> $GITHUB_ENV
+
+      - name: Test with MQST
+        run: |
+          cd nightly/NFD_DEV* || true
+          source env.sh
+          daqsystemtest_integtest_bundle.sh -l 0

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,0 +1,106 @@
+name: Run pytest
+
+on:
+  pull_request:
+
+jobs:
+  install_and_test:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: ghcr.io/dune-daq/nightly-release-alma9:development_v5
+
+    steps:
+      - name: Check URLs
+        run: |
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/druncschema.git
+          echo https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drunc.git
+
+      - name: Set up dev nightly
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir nightly
+          cd nightly
+          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+          setup_dbt latest_v5
+          dbt-create -n last_fddaq
+          cd NFD_DEV*
+          source env.sh
+          dbt-build
+          dbt-workarea-env
+
+      - name: Install druncschema and drunc
+        if: success()
+        run: |
+          cd nightly/NFD_DEV* || true
+          source env.sh
+          python -m pip install --upgrade pip
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/druncschema.git -b ${{ github.head_ref }} ||  git clone https://github.com/DUNE-DAQ/druncschema.git
+          git clone https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/drunc.git -b ${{ github.head_ref }}
+          cd druncschema
+          pip install .
+          cd -
+          cd drunc
+          pip install .
+          echo "DRUNC_DIR=$(pwd)" >> $GITHUB_ENV
+
+      - name: Test with pytest/pytest-cov
+        if: success()
+        run: |
+          cd nightly/NFD_DEV* || true
+          source env.sh
+          cd drunc || true
+          pip install pytest pytest-cov
+          pytest --junitxml=junit/test-results.xml --cov=drunc --cov-report=html
+
+      - name: Publish JUnit test report
+        uses: mikepenz/action-junit-report@v5
+        if: ${{ !cancelled() }}
+        with:
+          report_paths: '${{ env.DRUNC_DIR }}/junit/test-results.xml'
+
+      # - name: Deploy HTML coverage to GitHub Pages
+      #   if: ${{ !cancelled() }}
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ${{ env.DRUNC_DIR }}/htmlcov/
+      #     destination_dir: coverage/${{ github.ref_name }}  # This adds the branch name to the URL
+      #     publish_branch: gh-pages
+
+      # - name: Comment on PR
+      #   if: ${{ !cancelled() }}
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       github.rest.issues.createComment({
+      #         issue_number: context.issue.number,
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         body: 'Coverage report: https://dune-daq.github.io/drunc/coverage/${{ github.ref_name }}/index.html'
+      #       })
+
+      # - name: Upload JUnit test report
+      #   if: ${{ !cancelled() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: junit-report
+      #     path: ${{ env.DRUNC_DIR }}/junit/test-results.xml
+      #     if-no-files-found: error
+      #     retention-days: 7
+
+      - name: Upload coverage report (HTML)
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-coverage-report
+          path: ${{ env.DRUNC_DIR }}/htmlcov/
+          if-no-files-found: error
+          retention-days: 7
+
+

--- a/.github/workflows/track_new_issues.yml
+++ b/.github/workflows/track_new_issues.yml
@@ -1,0 +1,40 @@
+name: Add issue to project
+on:
+  issues:
+    types:
+      - opened   
+      
+jobs:
+  track_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_CI_ISSUES }}
+          ORGANIZATION: DUNE-DAQ
+          PROJECT_NUMBER: 5
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+                    
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_CI_ISSUES }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectV2ItemById.item.id')"        

--- a/.github/workflows/track_new_prs.yml
+++ b/.github/workflows/track_new_prs.yml
@@ -1,0 +1,40 @@
+name: Add pull request to project
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  track_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_CI_ISSUES }}
+          ORGANIZATION: DUNE-DAQ
+          PROJECT_NUMBER: 5
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+                    
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_CI_ISSUES }}
+        run: |
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            node_id=`curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER} | jq '.node_id'`
+            item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$node_id --jq '.data.addProjectV2ItemById.item.id')"    


### PR DESCRIPTION
# Description

This adds the `drunc` Workflows now that as of this morning `drunc_ui` has been added to the GitHub organization. 

Fixes #531

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist
N/A, this consists of Workflow additions rather than code changes. 

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
